### PR TITLE
Contact page update

### DIFF
--- a/pages/contact/index.js
+++ b/pages/contact/index.js
@@ -6,7 +6,7 @@ import {
 } from "@heroicons/react/outline";
 import {PopupButton} from "react-calendly";
 
-const issueGithub = 'https://github.com/mudmapio/public-interactions/issues/new/choose'
+const issueGithub = 'https://github.com/mudmap-io/customer-support/issues/new/choose'
 const supportLinks = [
   {
     name: 'Documentation',


### PR DESCRIPTION
Change the customer support url to reflect Mudmap org instead of old 'user' account.